### PR TITLE
Allow DELUGED_USER env variable to specify user

### DIFF
--- a/deluge-web.sh
+++ b/deluge-web.sh
@@ -1,3 +1,8 @@
 #!/bin/bash
 
-exec /sbin/setuser nobody deluge-web -c /config
+if [ -z "$DELUGED_USER" ]
+then
+	DELUGED_USER=nobody
+fi
+
+exec /sbin/setuser $DELUGED_USER deluge-web -c /config

--- a/deluged.sh
+++ b/deluged.sh
@@ -1,3 +1,8 @@
 #!/bin/bash
 
-exec /sbin/setuser nobody deluged -d -c /config -L info -l /config/deluged.log
+if [ -z "$DELUGED_USER" ]
+then
+        DELUGED_USER=nobody
+fi
+
+exec /sbin/setuser $DELUGED_USER deluged -d -c /config -L info -l /config/deluged.log


### PR DESCRIPTION
I'd rather have deluge run as a specified user instead of nobody.  This is first step to do it and won't change the default behavior.  
